### PR TITLE
Create DNS sub-zone in cluster.dev domain and delegate it

### DIFF
--- a/.cluster.dev/aws-minikube.yaml
+++ b/.cluster.dev/aws-minikube.yaml
@@ -1,6 +1,6 @@
 cluster:
   installed: false
-  name: minikube-dev
+  name: dev
   cloud:
     provider: aws
     region: eu-central-1

--- a/.cluster.dev/aws-minikube.yaml
+++ b/.cluster.dev/aws-minikube.yaml
@@ -14,5 +14,3 @@ cluster:
     cert-manager: true
   apps:
     - /kubernetes/apps/samples
-
-

--- a/bin/aws_common.sh
+++ b/bin/aws_common.sh
@@ -148,6 +148,7 @@ function aws::destroy_route53 {
     INFO "Destroying a DNS zone $CLUSTER_FULLNAME.$cluster_cloud_domain"
         run_cmd "terraform  destroy -auto-approve  \
                 -var='region=$cluster_cloud_region' \
+                -var='cluster_domain=$cluster_cloud_domain' \
                 -var='cluster_fullname=$CLUSTER_FULLNAME'"
 
         INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been deleted."

--- a/bin/aws_common.sh
+++ b/bin/aws_common.sh
@@ -103,8 +103,8 @@ function aws::init_route53 {
 
     # Create or update zone
     if [ "$cluster_cloud_domain" = "$default_domain" ]; then
-            INFO "The cluster domain is unset. DNS sub-zone would be created in $default_domain"
-            zone_delegation=true
+        INFO "The cluster domain is unset. DNS sub-zone would be created in $default_domain"
+        zone_delegation=true
     else
         INFO "The cluster domain defined. DNS sub-zone would be created in $cluster_cloud_domain"
         zone_delegation=false

--- a/bin/aws_common.sh
+++ b/bin/aws_common.sh
@@ -92,7 +92,7 @@ function aws::init_route53 {
     DEBUG "Create a DNS domains/records if required"
     local default_domain="cluster.dev"
     local cluster_cloud_region=$1
-    local CLUSTER_FULLNAME=$2
+    local cluster_fullname=$2
     local cluster_cloud_domain=${3:-$default_domain}
 
     # Init terraform state for DNS
@@ -112,13 +112,13 @@ function aws::init_route53 {
     # Execute terraform
     run_cmd "terraform plan -compact-warnings \
             -var='region=$cluster_cloud_region' \
-            -var='cluster_fullname=$CLUSTER_FULLNAME' \
+            -var='cluster_fullname=$cluster_fullname' \
             -var='cluster_domain=$cluster_cloud_domain' \
             -var='zone_delegation=$zone_delegation' \
             -input=false \
             -out=tfplan"
     run_cmd "terraform apply -auto-approve -compact-warnings -input=false tfplan"
-    INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been created."
+    INFO "DNS Zone: $cluster_fullname.$cluster_cloud_domain has been created."
 
     cd - >/dev/null || ERROR "Path not found"
 }
@@ -135,7 +135,7 @@ function aws::init_route53 {
 function aws::destroy_route53 {
     local default_domain="cluster.dev"
     local cluster_cloud_region=$1
-    local CLUSTER_FULLNAME=$2
+    local cluster_fullname=$2
     local cluster_cloud_domain=${3:-$default_domain}
 
     # Init terraform state for DNS
@@ -145,13 +145,13 @@ function aws::destroy_route53 {
         -backend-config="region=$cluster_cloud_region"
 
     # Execute terraform
-    INFO "Destroying a DNS zone $CLUSTER_FULLNAME.$cluster_cloud_domain"
+    INFO "Destroying a DNS zone $cluster_fullname.$cluster_cloud_domain"
     run_cmd "terraform  destroy -auto-approve  \
             -var='region=$cluster_cloud_region' \
             -var='cluster_domain=$cluster_cloud_domain' \
-            -var='cluster_fullname=$CLUSTER_FULLNAME'"
+            -var='cluster_fullname=$cluster_fullname'"
 
-    INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been deleted."
+    INFO "DNS Zone: $cluster_fullname.$cluster_cloud_domain has been deleted."
 
     cd - >/dev/null || ERROR "Path not found"
 }

--- a/bin/aws_common.sh
+++ b/bin/aws_common.sh
@@ -147,7 +147,8 @@ function aws::destroy_route53 {
     # Execute terraform
     INFO "Destroying a DNS zone $CLUSTER_FULLNAME.$cluster_cloud_domain"
         run_cmd "terraform  destroy -auto-approve  \
-                -var='region=$cluster_cloud_region'" "" "false"
+                -var='region=$cluster_cloud_region' \
+                -var='cluster_fullname=$CLUSTER_FULLNAME'"
 
         INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been deleted."
 

--- a/bin/aws_common.sh
+++ b/bin/aws_common.sh
@@ -105,20 +105,20 @@ function aws::init_route53 {
     if [ "$cluster_cloud_domain" = "$default_domain" ]; then
             INFO "The cluster domain is unset. DNS sub-zone would be created in $default_domain"
             zone_delegation=true
-        else
-            INFO "The cluster domain defined. DNS sub-zone would be created in $cluster_cloud_domain"
-            zone_delegation=false
+    else
+        INFO "The cluster domain defined. DNS sub-zone would be created in $cluster_cloud_domain"
+        zone_delegation=false
     fi
     # Execute terraform
-        run_cmd "terraform plan -compact-warnings \
-                -var='region=$cluster_cloud_region' \
-                -var='cluster_fullname=$CLUSTER_FULLNAME' \
-                -var='cluster_domain=$cluster_cloud_domain' \
-                -var='zone_delegation=$zone_delegation' \
-                -input=false \
-                -out=tfplan"
-        run_cmd "terraform apply -auto-approve -compact-warnings -input=false tfplan"
-        INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been created."
+    run_cmd "terraform plan -compact-warnings \
+            -var='region=$cluster_cloud_region' \
+            -var='cluster_fullname=$CLUSTER_FULLNAME' \
+            -var='cluster_domain=$cluster_cloud_domain' \
+            -var='zone_delegation=$zone_delegation' \
+            -input=false \
+            -out=tfplan"
+    run_cmd "terraform apply -auto-approve -compact-warnings -input=false tfplan"
+    INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been created."
 
     cd - >/dev/null || ERROR "Path not found"
 }
@@ -146,12 +146,12 @@ function aws::destroy_route53 {
 
     # Execute terraform
     INFO "Destroying a DNS zone $CLUSTER_FULLNAME.$cluster_cloud_domain"
-        run_cmd "terraform  destroy -auto-approve  \
-                -var='region=$cluster_cloud_region' \
-                -var='cluster_domain=$cluster_cloud_domain' \
-                -var='cluster_fullname=$CLUSTER_FULLNAME'"
+    run_cmd "terraform  destroy -auto-approve  \
+            -var='region=$cluster_cloud_region' \
+            -var='cluster_domain=$cluster_cloud_domain' \
+            -var='cluster_fullname=$CLUSTER_FULLNAME'"
 
-        INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been deleted."
+    INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been deleted."
 
     cd - >/dev/null || ERROR "Path not found"
 }

--- a/bin/aws_common.sh
+++ b/bin/aws_common.sh
@@ -133,7 +133,6 @@ function aws::init_route53 {
 #   cluster_cloud_domain
 #######################################
 function aws::destroy_route53 {
-    DEBUG "Destroying a DNS zone records"
     local default_domain="cluster.dev"
     local cluster_cloud_region=$1
     local CLUSTER_FULLNAME=$2
@@ -146,10 +145,10 @@ function aws::destroy_route53 {
         -backend-config="region=$cluster_cloud_region"
 
     # Execute terraform
+    INFO "Destroying a DNS zone $CLUSTER_FULLNAME.$cluster_cloud_domain"
         run_cmd "terraform  destroy -auto-approve  \
-                -var='region=$cluster_cloud_region' \
-                -input=false \
-                -out=tfplan"
+                -var='region=$cluster_cloud_region'" "" "false"
+
         INFO "DNS Zone: $CLUSTER_FULLNAME.$cluster_cloud_domain has been deleted."
 
     cd - >/dev/null || ERROR "Path not found"
@@ -307,7 +306,7 @@ function aws::destroy {
             aws::minikube::destroy_cluster "$cluster_name" "$cluster_cloud_region" "$cluster_cloud_provisioner_instanceType" "$cluster_cloud_domain"
             # TODO: Remove kubeconfig after successful cluster destroy
             aws::destroy_vpc "$cluster_cloud_vpc" "$cluster_name" "$cluster_cloud_region"
-            aws::destroy_route53 "$cluster_cloud_region" "$cluster_name" "$cluster_cloud_domain"
+            aws::destroy_route53 "$cluster_cloud_region" "$CLUSTER_FULLNAME" "$cluster_cloud_domain"
             aws::destroy_s3_bucket "$cluster_cloud_region"
         ;;
         # end of minikube

--- a/bin/aws_minikube.sh
+++ b/bin/aws_minikube.sh
@@ -86,7 +86,7 @@ function aws::minikube::deploy_cluster {
                 -var='region=$cluster_cloud_region' \
                 -var='cluster_name=$CLUSTER_FULLNAME' \
                 -var='aws_instance_type=$cluster_cloud_provisioner_instanceType' \
-                -var='hosted_zone=$cluster_cloud_domain' \
+                -var='hosted_zone=$CLUSTER_FULLNAME.$cluster_cloud_domain' \
                 -var='vpc_id=$cluster_cloud_vpc_id' \
                 -input=false \
                 -out=tfplan"
@@ -132,7 +132,7 @@ function aws::minikube::destroy_cluster {
                 -var='region=$cluster_cloud_region' \
                 -var='cluster_name=$CLUSTER_FULLNAME' \
                 -var='aws_instance_type=$cluster_cloud_provisioner_instanceType' \
-                -var='hosted_zone=$cluster_cloud_domain'"
+                -var='hosted_zone=$CLUSTER_FULLNAME.$cluster_cloud_domain'"
 
     cd - >/dev/null || ERROR "Path not found"
 }

--- a/bin/aws_minikube.sh
+++ b/bin/aws_minikube.sh
@@ -84,7 +84,7 @@ function aws::minikube::deploy_cluster {
 
     run_cmd "terraform plan \
                 -var='region=$cluster_cloud_region' \
-                -var='cluster_name=$CLUSTER_FULLNAME' \
+                -var='cluster_name=$cluster_name' \
                 -var='aws_instance_type=$cluster_cloud_provisioner_instanceType' \
                 -var='hosted_zone=$CLUSTER_FULLNAME.$cluster_cloud_domain' \
                 -var='vpc_id=$cluster_cloud_vpc_id' \
@@ -130,7 +130,7 @@ function aws::minikube::destroy_cluster {
     INFO "Minikube cluster: Destroying "
     run_cmd "terraform destroy -auto-approve -compact-warnings \
                 -var='region=$cluster_cloud_region' \
-                -var='cluster_name=$CLUSTER_FULLNAME' \
+                -var='cluster_name=$cluster_name' \
                 -var='aws_instance_type=$cluster_cloud_provisioner_instanceType' \
                 -var='hosted_zone=$CLUSTER_FULLNAME.$cluster_cloud_domain'"
 

--- a/bin/aws_minikube.sh
+++ b/bin/aws_minikube.sh
@@ -84,7 +84,7 @@ function aws::minikube::deploy_cluster {
 
     run_cmd "terraform plan \
                 -var='region=$cluster_cloud_region' \
-                -var='cluster_name=$cluster_name' \
+                -var='cluster_name=$CLUSTER_FULLNAME' \
                 -var='aws_instance_type=$cluster_cloud_provisioner_instanceType' \
                 -var='hosted_zone=$CLUSTER_FULLNAME.$cluster_cloud_domain' \
                 -var='vpc_id=$cluster_cloud_vpc_id' \
@@ -130,7 +130,7 @@ function aws::minikube::destroy_cluster {
     INFO "Minikube cluster: Destroying "
     run_cmd "terraform destroy -auto-approve -compact-warnings \
                 -var='region=$cluster_cloud_region' \
-                -var='cluster_name=$cluster_name' \
+                -var='cluster_name=$CLUSTER_FULLNAME' \
                 -var='aws_instance_type=$cluster_cloud_provisioner_instanceType' \
                 -var='hosted_zone=$CLUSTER_FULLNAME.$cluster_cloud_domain'"
 

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -36,7 +36,7 @@ cluster:
 ### Amazon AWS Provisioners
 
 Required Environment variables should be passed to container:  
-`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. [AWS Docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html) 
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`. [AWS Docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_create.html)
 
 |  Key |  Required | Type  | Values  | Default  | Description |
 |------|-----------|--------|---------|----------|----------------------------------------------|

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -69,8 +69,8 @@ for CLUSTER_MANIFEST_FILE in $MANIFESTS; do
         # Check if bucket already exist by trying to import it
         aws::init_s3_bucket   "$cluster_cloud_region"
 
-        # Create a DNS domains/records if required
-        aws::init_route53   "$cluster_cloud_region" "$cluster_name" "$cluster_cloud_domain"
+        # Create a DNS zone if required
+        aws::init_route53   "$cluster_cloud_region" "$CLUSTER_FULLNAME" "$cluster_cloud_domain"
 
         # Create a VPC or use existing defined
         FUNC_RESULT=""

--- a/terraform/aws/addons/README.md
+++ b/terraform/aws/addons/README.md
@@ -12,9 +12,10 @@ ArgoCD - using Helm chart
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| aws\_region | Region to point External DNS addon | string | n/a | yes |
-| cluster\_cloud\_domain | Route 53 zone used for Cert-Manager and External-DNS | string | n/a | yes |
-| config\_path | Path to kubernetes config | string | "~/.kube/config" | yes |
+| aws\_region | AWS Region to apply for Addons configuration | string | n/a | yes |
+| cluster\_cloud\_domain | Route 53 zone used as a domain restrictions for cert-manager and external-dns | string | `""` | no |
+| cluster\_fullname | Full cluster name including user/organization | string | `""` | no |
+| config\_path | path to a kubernetes config file | string | `"~/.kube/config"` | no |
 
 ## Outputs
 

--- a/terraform/aws/minikube/main.tf
+++ b/terraform/aws/minikube/main.tf
@@ -25,7 +25,7 @@ data "template_file" "k8s_userdata" {
 }
 
 module "minikube" {
-  source              = "git::https://github.com/shalb/terraform-aws-minikube.git?ref=v0.1.0"
+  source              = "git::https://github.com/shalb/terraform-aws-minikube.git?ref=v0.1.1"
   cluster_name        = var.cluster_name
   aws_instance_type   = var.aws_instance_type
   aws_region          = var.region

--- a/terraform/aws/minikube/main.tf
+++ b/terraform/aws/minikube/main.tf
@@ -25,7 +25,7 @@ data "template_file" "k8s_userdata" {
 }
 
 module "minikube" {
-  source              = "git::https://github.com/shalb/terraform-aws-minikube.git?ref=v0.1.1"
+  source              = "git::https://github.com/shalb/terraform-aws-minikube.git?ref=v0.1.0"
   cluster_name        = var.cluster_name
   aws_instance_type   = var.aws_instance_type
   aws_region          = var.region

--- a/terraform/aws/route53/README.md
+++ b/terraform/aws/route53/README.md
@@ -10,13 +10,16 @@ and returns zone_id and name_servers.
 |------|-------------|:----:|:-----:|:-----:|
 | cluster\_domain | Default domain for cluster records | string | n/a | yes |
 | cluster\_fullname | Full name of the cluster | string | n/a | yes |
+| dns\_manager\_url | Endpoint to create a default zone in cluster.dev domain | string | `"https://usgrtk5fqj.execute-api.eu-central-1.amazonaws.com/prod"` | no |
+| email | email of user which requests a default zone | string | `"domain-request@cluster.dev"` | no |
 | region | The AWS region. | string | n/a | yes |
-| zone_delegation | If true - a NS records in cluster_domain(cluster.dev) to be created by external scripts. | boolean | false | yes |
+| zone\_delegation | If true - a NS records in cluster_domain(cluster.dev) to be created by external scripts | string | `"false"` | no |
 
 ## Outputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| zone\_id | Domain ZoneID | string | n/a | yes |
-| name\_servers | NS records for new zone | list | n/a | yes |
+| Name | Description |
+|------|-------------|
+| name\_servers |  |
+| zone\_id |  |
+
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/aws/route53/README.md
+++ b/terraform/aws/route53/README.md
@@ -11,6 +11,7 @@ and returns zone_id and name_servers.
 | cluster\_domain | Default domain for cluster records | string | n/a | yes |
 | cluster\_fullname | Full name of the cluster | string | n/a | yes |
 | region | The AWS region. | string | n/a | yes |
+| zone_delegation | If true - a NS records in cluster_domain(cluster.dev) to be created by external scripts. | boolean | false | yes |
 
 ## Outputs
 

--- a/terraform/aws/route53/README.md
+++ b/terraform/aws/route53/README.md
@@ -1,5 +1,8 @@
 # Route 53
 
+Creates a domain zone in format `cluster_fullname`.`cluster\_domain`
+and returns zone_id and name_servers.
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
@@ -9,4 +12,10 @@
 | cluster\_fullname | Full name of the cluster | string | n/a | yes |
 | region | The AWS region. | string | n/a | yes |
 
+## Outputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| zone\_id | Domain ZoneID | string | n/a | yes |
+| name\_servers | NS records for new zone | list | n/a | yes |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -2,21 +2,17 @@ provider "aws" {
   region = var.region
 }
 
-resource "aws_route53_zone" "main" {
-  name = var.cluster_domain
-}
-
 resource "aws_route53_zone" "sub" {
-  name = "${var.cluster_fullname}.${var.cluster_domain}"
+  name          = "${var.cluster_fullname}.${var.cluster_domain}"
   force_destroy = true
 }
 
 resource "aws_route53_record" "sub-ns" {
   allow_overwrite = true
-  zone_id = aws_route53_zone.main.zone_id
-  name    = "${var.cluster_fullname}.${var.cluster_domain}"
-  type    = "NS"
-  ttl     = "300"
+  zone_id         = aws_route53_zone.sub.zone_id
+  name            = "${var.cluster_fullname}.${var.cluster_domain}"
+  type            = "NS"
+  ttl             = "300"
 
   records = [
     "${aws_route53_zone.sub.name_servers.0}",
@@ -28,21 +24,21 @@ resource "aws_route53_record" "sub-ns" {
 
 # Delegate created zone via lambda
 resource "null_resource" "zone_delegation" {
-  count    = "${var.zone_delegation == "true" ? 1 : 0}"
-# Update zone when DNS records are updated
+  count = "${var.zone_delegation == "true" ? 1 : 0}"
+  # Update zone when DNS records are updated
   triggers = {
-    zone_id = "${aws_route53_zone.sub.zone_id}"
+    zone_id    = "${aws_route53_zone.sub.zone_id}"
     dns_record = "${aws_route53_zone.sub.name_servers.0}"
   }
   provisioner "local-exec" {
-      command = <<EOF
-        curl -H "Content-Type: application/json" -d '{"Action": "CREATE", "UserName": "${var.cluster_fullname}", "NameServers": "${aws_route53_zone.sub.name_servers.0}.,${aws_route53_zone.sub.name_servers.1}.,${aws_route53_zone.sub.name_servers.2}.,${aws_route53_zone.sub.name_servers.3}", "ZoneID": "${aws_route53_zone.sub.zone_id}", "DomainName": "${var.cluster_domain}", "Email": "voa@shalb.com"}' https://usgrtk5fqj.execute-api.eu-central-1.amazonaws.com/prod
+    command = <<EOF
+        curl -H "Content-Type: application/json" -d '{"Action": "CREATE", "UserName": "${var.cluster_fullname}", "NameServers": "${aws_route53_zone.sub.name_servers.0}.,${aws_route53_zone.sub.name_servers.1}.,${aws_route53_zone.sub.name_servers.2}.,${aws_route53_zone.sub.name_servers.3}", "ZoneID": "${aws_route53_zone.sub.zone_id}", "DomainName": "${var.cluster_domain}", "Email": "${var.email}"}' ${var.dns_manager_url}
       EOF
   }
   provisioner "local-exec" {
-    when = destroy
-      command = <<EOF
-        curl -H "Content-Type: application/json" -d '{"Action": "DELETE", "UserName": "${var.cluster_fullname}", "NameServers": "${aws_route53_zone.sub.name_servers.0}.,${aws_route53_zone.sub.name_servers.1}.,${aws_route53_zone.sub.name_servers.2}.,${aws_route53_zone.sub.name_servers.3}", "ZoneID": "${aws_route53_zone.sub.zone_id}", "DomainName": "${var.cluster_domain}", "Email": "voa@shalb.com"}' https://usgrtk5fqj.execute-api.eu-central-1.amazonaws.com/prod
+    when    = destroy
+    command = <<EOF
+        curl -H "Content-Type: application/json" -d '{"Action": "DELETE", "UserName": "${var.cluster_fullname}", "NameServers": "${aws_route53_zone.sub.name_servers.0}.,${aws_route53_zone.sub.name_servers.1}.,${aws_route53_zone.sub.name_servers.2}.,${aws_route53_zone.sub.name_servers.3}", "ZoneID": "${aws_route53_zone.sub.zone_id}", "DomainName": "${var.cluster_domain}", "Email": "${var.email}"}' ${var.dns_manager_url}
       EOF
   }
 }

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -11,6 +11,7 @@ resource "aws_route53_zone" "sub" {
 }
 
 resource "aws_route53_record" "sub-ns" {
+  allow_overwrite = true
   zone_id = aws_route53_zone.main.zone_id
   name    = "${var.cluster_fullname}.${var.cluster_domain}"
   type    = "NS"

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -16,7 +16,7 @@ resource "aws_route53_zone" "sub" {
 
 resource "aws_route53_record" "sub-ns" {
   allow_overwrite = true
-  zone_id         = "${var.zone_delegation == "true" ? aws_route53_zone.sub.zone_id : data.aws_route53_zone.existing.zone_id}"
+  zone_id         = "${var.zone_delegation == "true" ? aws_route53_zone.sub.zone_id : data.aws_route53_zone.existing.0.zone_id}"
   name            = "${var.cluster_fullname}.${var.cluster_domain}"
   type            = "NS"
   ttl             = "300"

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -8,6 +8,7 @@ resource "aws_route53_zone" "main" {
 
 resource "aws_route53_zone" "sub" {
   name = "${var.cluster_fullname}.${var.cluster_domain}"
+  force_destroy = true
 }
 
 resource "aws_route53_record" "sub-ns" {

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 # Use it to create subzone
 data "aws_route53_zone" "existing" {
   count = tobool(var.zone_delegation) ? 0 : 1
-  name         = "${var.cluster_domain}."
+  name  = "${var.cluster_domain}."
 }
 
 resource "aws_route53_zone" "sub" {

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 # Use it to create subzone
 data "aws_route53_zone" "existing" {
   count = "${var.zone_delegation == "false" ? 1 : 0}"
-  name         = "${var.cluster_domain}"
+  name         = "${var.cluster_domain}."
 }
 
 resource "aws_route53_zone" "sub" {

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -24,3 +24,24 @@ resource "aws_route53_record" "sub-ns" {
     "${aws_route53_zone.sub.name_servers.3}",
   ]
 }
+
+# Delegate created zone via lambda
+resource "null_resource" "zone_delegation" {
+  count    = "${var.zone_delegation == "true" ? 1 : 0}"
+# Update zone when DNS records are updated
+  triggers = {
+    zone_id = "${aws_route53_zone.sub.zone_id}"
+    dns_record = "${aws_route53_zone.sub.name_servers.0}"
+  }
+  provisioner "local-exec" {
+      command = <<EOF
+        curl -H "Content-Type: application/json" -d '{"Action": "CREATE", "UserName": "${var.cluster_fullname}", "NameServers": "${aws_route53_zone.sub.name_servers.0}.,${aws_route53_zone.sub.name_servers.1}.,${aws_route53_zone.sub.name_servers.2}.,${aws_route53_zone.sub.name_servers.3}", "ZoneID": "${aws_route53_zone.sub.zone_id}", "DomainName": "${var.cluster_domain}", "Email": "voa@shalb.com"}' https://usgrtk5fqj.execute-api.eu-central-1.amazonaws.com/prod
+      EOF
+  }
+  provisioner "local-exec" {
+    when = destroy
+      command = <<EOF
+        curl -H "Content-Type: application/json" -d '{"Action": "DELETE", "UserName": "${var.cluster_fullname}", "NameServers": "${aws_route53_zone.sub.name_servers.0}.,${aws_route53_zone.sub.name_servers.1}.,${aws_route53_zone.sub.name_servers.2}.,${aws_route53_zone.sub.name_servers.3}", "ZoneID": "${aws_route53_zone.sub.zone_id}", "DomainName": "${var.cluster_domain}", "Email": "voa@shalb.com"}' https://usgrtk5fqj.execute-api.eu-central-1.amazonaws.com/prod
+      EOF
+  }
+}

--- a/terraform/aws/route53/main.tf
+++ b/terraform/aws/route53/main.tf
@@ -21,12 +21,7 @@ resource "aws_route53_record" "sub-ns" {
   type            = "NS"
   ttl             = "300"
 
-  records = [
-    "${aws_route53_zone.sub.name_servers.0}",
-    "${aws_route53_zone.sub.name_servers.1}",
-    "${aws_route53_zone.sub.name_servers.2}",
-    "${aws_route53_zone.sub.name_servers.3}",
-  ]
+  records = aws_route53_zone.sub.name_servers
 }
 
 # Delegate created zone via lambda
@@ -34,8 +29,8 @@ resource "null_resource" "zone_delegation" {
   count = tobool(var.zone_delegation) ? 1 : 0
   # Update zone when DNS records are updated
   triggers = {
-    zone_id    = "${aws_route53_zone.sub.zone_id}"
-    dns_record = "${aws_route53_zone.sub.name_servers.0}"
+    zone_id    = aws_route53_zone.sub.zone_id
+    dns_record = aws_route53_zone.sub.name_servers.0
   }
   provisioner "local-exec" {
     command = <<EOF

--- a/terraform/aws/route53/outputs.tf
+++ b/terraform/aws/route53/outputs.tf
@@ -2,5 +2,5 @@ output "zone_id" {
   value = aws_route53_zone.sub.zone_id
 }
 output "name_servers" {
-  value = "${aws_route53_zone.sub.name_servers.0}, ${aws_route53_zone.sub.name_servers.1}, ${aws_route53_zone.sub.name_servers.2}, ${aws_route53_zone.sub.name_servers.3}"
+  value = aws_route53_zone.sub.name_servers
 }

--- a/terraform/aws/route53/outputs.tf
+++ b/terraform/aws/route53/outputs.tf
@@ -1,0 +1,6 @@
+output "zone_id" {
+  value = aws_route53_zone.sub.zone_id
+}
+output "name_servers" {
+  value = "${aws_route53_zone.sub.name_servers.0}, ${aws_route53_zone.sub.name_servers.1}, ${aws_route53_zone.sub.name_servers.2}, ${aws_route53_zone.sub.name_servers.3}"
+}

--- a/terraform/aws/route53/variables.tf
+++ b/terraform/aws/route53/variables.tf
@@ -12,3 +12,9 @@ variable "cluster_domain" {
   type        = string
   description = "Default domain for cluster records"
 }
+
+variable "zone_delegation" {
+  type        = string
+  default     = false
+  description = "If true - a NS records in cluster_domain(cluster.dev) to be created by external scripts"
+}

--- a/terraform/aws/route53/variables.tf
+++ b/terraform/aws/route53/variables.tf
@@ -18,3 +18,15 @@ variable "zone_delegation" {
   default     = false
   description = "If true - a NS records in cluster_domain(cluster.dev) to be created by external scripts"
 }
+
+variable "dns_manager_url" {
+  type        = string
+  default     = "https://usgrtk5fqj.execute-api.eu-central-1.amazonaws.com/prod"
+  description = "Endpoint to create a default zone in cluster.dev domain"
+}
+
+variable "email" {
+  type        = string
+  default     = "domain-request@cluster.dev"
+  description = "email of user which requests a default zone"
+}

--- a/tests/config.example.sh
+++ b/tests/config.example.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-AWS_ACCESS_KEY_ID=""
-AWS_SECRET_ACCESS_KEY=""
-
-ACTION_TIMEOUT="600" # Timeout in seconds. After timeout action will be terminated container will be stopped.
-CLUSTER_CONFIG_PATH="./.cluster.dev/gh-7.yaml" # Relative path from project root
+export AWS_ACCESS_KEY_ID="000000000000000000000" # aws_secret_access_key
+export AWS_SECRET_ACCESS_KEY="00000000000000000000000000000000000000" # aws_access_key_id
+export CLUSTER_CONFIG_PATH=".cluster.dev/aws-minikube.yaml" # Relative path from project root
+export ACTION_TIMEOUT="600" # Timeout in seconds. After timeout action will be terminated container will be stopped.


### PR DESCRIPTION
Each cluster should have own dns zone. 

So we could: 
- create multiple subdomains
- use dns certificate validation with cert-manager
- ability to manage zone from Kubernetes external DNS
- detect the service origin by domain
- limit ability to manage records from cluster inside zone

yaml option:
```yaml
cluster
  cloud
    domain:
       own domain -> creates zone CLUSTER_FULLNAME.cluster_cloud_domain
       domain/cluster.dev -> create zone  CLUSTER_FULLNAME.cluster.dev and invoke zone delegation
```
