### PR TITLE
add workflow for docker publishing to dockerhub

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run tests
         run: |
-          docker build . --file Dockerfile
+          docker build . 
 
   # Push image to Docker Hub
   push:
@@ -70,10 +70,10 @@ jobs:
           echo VERSION=$VERSION
           
           docker tag "$IMAGE" "$REGISTRY/$IMAGE:$VERSION"
-          docker push "$IMAGE:$VERSION"
+          docker push "$REGISTRY/$IMAGE:$VERSION"
           
           docker tag "$IMAGE" "$REGISTRY/$IMAGE:latest"
-          docker push "$IMAGE:latest"
+          docker push "$REGISTRY/$IMAGE:latest"
 
       - name: Push image for master branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -1,0 +1,103 @@
+name: Docker
+
+on:
+
+  # Publish releases as 'latest'.
+  release:
+    types: [published]
+
+  push:
+    # Publish `master` as Docker `master-latest` image
+    # Publish for any branch as well
+    branches:
+      - master
+      - '*'
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - 'v*'
+
+  # Run tests for any PRs.
+  pull_request:
+
+
+env:
+  IMAGE_NAME: cluster.dev
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          docker build . --file Dockerfile
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login --username mk51 --password ${{ secrets.DOCKER_PASS }}
+
+
+      - name: Push image for release
+        if: github.event_name == 'release'
+        run: |
+          IMAGE_ID=docker.io/clusterdev/$IMAGE_NAME
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:latest
+          docker push $IMAGE_ID:latest
+
+      - name: Push image for master branch
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          IMAGE_ID=docker.io/clusterdev/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION="master-latest"
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION-${GITHUB_SHA}
+          docker push $IMAGE_ID:$VERSION-${GITHUB_SHA}
+
+      - name: Push image for other branch
+        if: github.event_name == 'push' && github.ref != 'refs/heads/master'
+        run: |
+          IMAGE_ID=docker.io/clusterdev/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # Strip git ref prefix from version
+          VERSION=${GITHUB_REF#refs/heads/}
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION-${GITHUB_SHA}
+          docker push $IMAGE_ID:$VERSION-${GITHUB_SHA}

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -22,11 +22,11 @@ on:
 
 
 env:
-  IMAGE_NAME: cluster.dev
+  IMAGE: cluster.dev
+  REGISTRY: docker.io/clusterdev
 
 jobs:
-  # Run tests.
-  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  # Run tests
   test:
     runs-on: ubuntu-latest
 
@@ -37,8 +37,7 @@ jobs:
         run: |
           docker build . --file Dockerfile
 
-  # Push image to GitHub Packages.
-  # See also https://docs.docker.com/docker-hub/builds/
+  # Push image to Docker Hub
   push:
     # Ensure test job passes before pushing image.
     needs: test
@@ -49,54 +48,52 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+        run: run: docker build -t $IMAGE .
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login --username mk51 --password ${{ secrets.DOCKER_PASS }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login --username ${{ secrets.DOCKER_USER }} --password ${{ secrets.DOCKER_PASS }}
 
 
       - name: Push image for release
         if: github.event_name == 'release'
         run: |
-          IMAGE_ID=docker.io/clusterdev/$IMAGE_NAME
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          
           # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo "$VERSION" | sed -e 's/^v//')
+          
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
+          
+          echo IMAGE=$IMAGE
           echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:latest
-          docker push $IMAGE_ID:latest
+          
+          docker tag "$IMAGE" "$REGISTRY/$IMAGE:$VERSION"
+          docker push "$IMAGE:$VERSION"
+          
+          docker tag "$IMAGE" "$REGISTRY/$IMAGE:latest"
+          docker push "$IMAGE:latest"
 
       - name: Push image for master branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
-          IMAGE_ID=docker.io/clusterdev/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           VERSION="master-latest"
-          echo IMAGE_ID=$IMAGE_ID
+          
+          echo IMAGE=$IMAGE
           echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION-${GITHUB_SHA}
-          docker push $IMAGE_ID:$VERSION-${GITHUB_SHA}
+          
+          docker tag "$IMAGE" "$REGISTRY/$IMAGE:$VERSION-${GITHUB_SHA}"
+          docker push "$REGISTRY/$IMAGE:$VERSION-${GITHUB_SHA}"
 
       - name: Push image for other branch
         if: github.event_name == 'push' && github.ref != 'refs/heads/master'
         run: |
-          IMAGE_ID=docker.io/clusterdev/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           #Get branch name
           VERSION=${GITHUB_REF#refs/heads/}
-          echo IMAGE_ID=$IMAGE_ID
+          
+          echo IMAGE_ID=$IMAGE
           echo VERSION=$VERSION
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION-${GITHUB_SHA}
-          docker push $IMAGE_ID:$VERSION-${GITHUB_SHA}
+          
+          docker tag "$IMAGE" "$REGISTRY/$IMAGE:$VERSION-${GITHUB_SHA}"
+          docker push "$REGISTRY/$IMAGE:$VERSION-${GITHUB_SHA}"

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -34,8 +34,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run tests
-        run: |
-          docker build . 
+        run: docker build . 
 
   # Push image to Docker Hub
   push:

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -51,7 +51,7 @@ jobs:
         run: docker build -t $IMAGE .
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login --username ${{ secrets.DOCKER_USER }} --password ${{ secrets.DOCKER_PASS }}
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login --username "${{ secrets.DOCKER_USER }}" --password "${{ secrets.DOCKER_PASS }}"
 
 
       - name: Push image for release

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -81,7 +81,6 @@ jobs:
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
           VERSION="master-latest"
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
@@ -95,7 +94,7 @@ jobs:
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
+          #Get branch name
           VERSION=${GITHUB_REF#refs/heads/}
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION


### PR DESCRIPTION
According the issue #63 I've created GitHub Action workflow for build and publishing docker image. 

Cases: 

1. Each time when master update, push image with tag  :master-latest + commitSHA
2. When branch creates/updates  - :branch-latest + commitSHA
3. When new release is published then push tag :latest and v* (release version)

Workflow is required  secret for docker.io as well. 

Close #63