### PR TITLE
Update pre-commit hooks

### DIFF
--- a/.github/workflows/pre-commit-main.yaml
+++ b/.github/workflows/pre-commit-main.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: lablabs/setup-terraform-docs@v1
       name: Setup Terraform docs
       with:
-        terraform_docs_version: v0.9.1
+        terraform_docs_version: v0.10.1
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'

--- a/.github/workflows/pre-commit-pr.yaml
+++ b/.github/workflows/pre-commit-pr.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: lablabs/setup-terraform-docs@v1
       name: Setup Terraform docs
       with:
-        terraform_docs_version: v0.9.1
+        terraform_docs_version: v0.10.1
     - uses: actions/setup-python@v2
       with:
         python-version: '3.8'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
 # ALL #
 #######
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.2.3
+  rev: v3.3.0
   hooks:
     # Git style
     - id: check-added-large-files
@@ -34,18 +34,22 @@ repos:
 # TERRAFORM #
 #############
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.28.0
+  rev: v1.43.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
-    - id: terraform_validate
+
+- repo: https://github.com/gruntwork-io/pre-commit
+  rev: v0.1.10
+  hooks:
+    - id: terraform-validate
 
 ##########
 # PYTHON #
 ##########
 
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.2.0
+  rev: v2.3.5
   hooks:
     - id: reorder-python-imports
       language_version: python3.8
@@ -57,7 +61,7 @@ repos:
       language_version: python3.8
 
 - repo: https://github.com/pre-commit/mirrors-autopep8
-  rev: v1.5.2
+  rev: v1.5.4
   hooks:
     - id: autopep8
       language_version: python3.8
@@ -68,7 +72,7 @@ repos:
 
 # Usage: http://pylint.pycqa.org/en/latest/user_guide/message-control.html
 - repo: https://github.com/PyCQA/pylint
-  rev: pylint-2.5.2
+  rev: pylint-2.6.0
   hooks:
     - id: pylint
       language_version: python3.8
@@ -82,7 +86,7 @@ repos:
       - --min-similarity-lines=8 # ignore stubs of dev dependencies
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.770
+  rev: v0.790
   hooks:
     - id: mypy
       language_version: python3.8
@@ -93,7 +97,7 @@ repos:
       ]
 
 - repo: https://gitlab.com/pycqa/flake8.git
-  rev: 3.8.2
+  rev: 3.8.4
   hooks:
   - id: flake8
     language_version: python3.8


### PR DESCRIPTION
Fixes #94 

I've updated all included pre-commit hooks.

Existing `pre-commit-terraform` with latest version has a lot of issues that I was not able to reliably fix for all platforms. While `terraform-validate` from https://github.com/gruntwork-io/pre-commit works just fine and does not require any additional setup.

UPD: looks like docker push step is failing because secrets are not available for workflows that run from forks.