### PR TITLE
Pin TF and Python versions for pre-commit

### DIFF
--- a/.github/workflows/pre-commit-main.yaml
+++ b/.github/workflows/pre-commit-main.yaml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ~0.12
     - uses: lablabs/setup-terraform-docs@v1
       name: Setup Terraform docs
       with:

--- a/.github/workflows/pre-commit-pr.yaml
+++ b/.github/workflows/pre-commit-pr.yaml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: ~0.12
     - uses: lablabs/setup-terraform-docs@v1
       name: Setup Terraform docs
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 # How to install:
 # pre-commit install --install-hooks && pre-commit install --install-hooks -t commit-msg
 
+default_language_version:
+  python: python3
+
 # How temporary skip one of hooks: https://pre-commit.com/#temporarily-disabling-hooks
 
 repos:


### PR DESCRIPTION
Pining tf version to 0.12.* because GH action vms default to 0.13
