### PR TITLE
Add Verbose errors for yaml

### DIFF
--- a/pkg/project/infra_template.go
+++ b/pkg/project/infra_template.go
@@ -1,12 +1,14 @@
 package project
 
 import (
-	"fmt"
-
-	"github.com/Masterminds/semver"
-	"github.com/apex/log"
-	"github.com/shalb/cluster.dev/pkg/config"
-	"gopkg.in/yaml.v3"
+  "fmt"
+  "github.com/Masterminds/semver"
+  "github.com/apex/log"
+  "github.com/shalb/cluster.dev/pkg/config"
+  "gopkg.in/yaml.v3"
+  "regexp"
+  "strconv"
+  "strings"
 )
 
 const infraTemplateObjKindKey = "InfraTemplate"
@@ -18,14 +20,60 @@ type InfraTemplate struct {
 	ReqClientVersion string                   `yaml:"cliVersion"`
 }
 
+func FindLineNumInYamlError (err error) []int {
+  var list []int
+  re := regexp.MustCompile(`line (\d+):`)
+  submatch := re.FindStringSubmatch(err.Error())
+  if len(submatch) > 0 {
+    for _, lineStr := range submatch[1:] {
+      lineNum, err := strconv.Atoi(lineStr)
+      if err == nil {
+        list = append(list, lineNum)
+      }
+    }
+  }
+  return list
+}
+
+func NewYamlError(data []byte, lines []int) string {
+  if len(lines) == 0 {
+    return ""
+  }
+  errString := []string{", Details:"}
+  num := lines[0] // TODO: Need to check if multiple lines can be returned in the error
+  iterator := 0
+  startPosition := 0
+  startFilecorrection := 0
+  if num - 3 > 0 {
+    startPosition = num - 3
+  } else {
+    startFilecorrection = num - 4
+  }
+  for _, k := range strings.Split(string(data), "\n")[startPosition:] {
+    lineNum := startPosition + 1 + iterator
+    lineText := fmt.Sprintf("%v: %s", lineNum, k)
+    if iterator == num - startPosition - 1 {
+      lineText = lineText + "   <<<<<<<<<"
+    }
+    errString = append(errString, lineText)
+    iterator++
+    if iterator == 7 + startFilecorrection {
+      break
+    }
+  }
+  return strings.Join(errString, "\n")
+}
+
 func NewInfraTemplate(data []byte) (*InfraTemplate, error) {
 	iTmpl := InfraTemplate{}
 	err := yaml.Unmarshal(data, &iTmpl)
 	if err != nil {
+	  errNum := FindLineNumInYamlError(err)
+	  yamlErr := NewYamlError(data, errNum)
 		if config.Global.TraceLog {
 			log.Debug(string(data))
 		}
-		return nil, fmt.Errorf("unmarshal template data: %v", err.Error())
+		return nil, fmt.Errorf("unmarshal template data: %v %v", err.Error(), yamlErr)
 	}
 	if len(iTmpl.Modules) < 1 {
 		return nil, fmt.Errorf("parsing template: template must contain at least one module")

--- a/pkg/project/infra_template_test.go
+++ b/pkg/project/infra_template_test.go
@@ -1,0 +1,60 @@
+package project
+
+import (
+  "fmt"
+  "testing"
+)
+
+func TestFindLineNumInYamlError(t *testing.T) {
+  err := fmt.Errorf("yaml: line 24: mapping values are not allowed in this context")
+  list := FindLineNumInYamlError(err)
+  expectedNum := 24
+  if len(list) != 1 || list[0] != expectedNum {
+    t.Errorf("Expected: [%v], actual value: %v", expectedNum, list)
+    t.Fail()
+  }
+
+  err = fmt.Errorf("yaml: line 24: mapping values are not allowed in this context yaml: line 99: mapping values are not allowed in this context")
+  list = FindLineNumInYamlError(err)
+  expectedNum1 := 24
+  if len(list) != 1 || list[0] != expectedNum1 {
+    t.Errorf("Expected: [%v], actual value: %v", expectedNum1, list)
+    t.Fail()
+  }
+}
+
+func TestNewYamlError(t *testing.T) {
+  testList := []byte(`line1
+line2
+line3
+line4
+line5
+line6
+line7
+line8
+line9
+line10`)
+  resultWith0 := NewYamlError(testList, []int{1})
+  expectedResult := `, Details:
+1: line1   <<<<<<<<<
+2: line2
+3: line3
+4: line4`
+  if resultWith0 != expectedResult {
+    t.Errorf("Expected: [%v], actual value: [%v]", expectedResult, resultWith0)
+    t.Fail()
+  }
+  resultWith5 := NewYamlError(testList, []int{5})
+  expectedResult = `, Details:
+3: line3
+4: line4
+5: line5   <<<<<<<<<
+6: line6
+7: line7
+8: line8
+9: line9`
+  if resultWith5 != expectedResult {
+    t.Errorf("Expected: [%v], actual value: [%v]", expectedResult, resultWith5)
+    t.Fail()
+  }
+}


### PR DESCRIPTION
Show lines related to yaml error
```
16:27:47 [FATAL] Fatal error: apply: unmarshal template data: yaml: line 24: mapping values are not allowed in this context , Details:
22:       zone_delegation: false
23:   - name: vpc
24:     type: a: terraform   <<<<<<<<<
25:     providers: *provider_aws
26:     source: terraform-aws-modules/vpc/aws
27:     version: "2.70.0"
28:     inputs:
```
