### PR TITLE
Helm set values

### DIFF
--- a/docs/units-helm.md
+++ b/docs/units-helm.md
@@ -22,8 +22,13 @@ units:
     values:
       - file: ./argo/values.yaml
         apply_template: true
+      - set:
+          global:
+            image:
+              tag: "v1.8.3"
+      - set: {{ insertYaml .varables.argocd.values }}
     inputs:
-      global.image.tag: v1.8.3
+      global.image.tag: v1.8.3 # (same as values.set )
 ```
 
 In addition to common options the following are available:
@@ -39,11 +44,13 @@ In addition to common options the following are available:
 
 * `additional_options` - *map of any*, *optional*. Corresponds to [Terraform helm_release resource options](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#argument-reference). Will be passed as is.
 
-* `values` - *array*, *optional*. List of values files in raw yaml to be passed to Helm. Values will be merged, in order, as Helm does with multiple -f options.
+* `values` - *array*, *optional*. List of values (file name or values data) to be passed to Helm. Values will be merged, in order, as Helm does with multiple -f options.
 
-    * `file` - *string*, *required*. Path to the values file.
+    * `set` - *map of any*, *required one of set/file*. Set of helm values.
 
-    * `apply_template` - *bool*, *optional*. Defines whether a template should be applied to the values file. By default is set to `true`. 
+    * `file` - *string*, *required one of set/file*. Path to the values file.
+
+    * `apply_template` - *bool*, *optional*. Defines whether a template should be applied to the values file. By default is set to `true`. Used only with `file` option
 
 * `inputs` - *map of any*, *optional*. A map that represents [Terraform helm_release sets](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release#set). This block allows to use functions `remoteState` and `insertYAML`. For example:
 

--- a/pkg/cmd/cdev/apply.go
+++ b/pkg/cmd/cdev/apply.go
@@ -19,6 +19,7 @@ var applyCmd = &cobra.Command{
 			return NewCmdErr(project, "apply", err)
 		}
 		err = project.LockState()
+		defer project.UnLockState()
 		if err != nil {
 			return NewCmdErr(project, "apply", err)
 		}

--- a/pkg/cmd/cdev/destroy.go
+++ b/pkg/cmd/cdev/destroy.go
@@ -17,6 +17,7 @@ var destroyCmd = &cobra.Command{
 			return NewCmdErr(project, "destroy", err)
 		}
 		err = project.LockState()
+		defer project.UnLockState()
 		if err != nil {
 			return NewCmdErr(project, "destroy", err)
 		}

--- a/pkg/cmd/cdev/main.go
+++ b/pkg/cmd/cdev/main.go
@@ -58,9 +58,9 @@ func Run() {
 	if p != nil {
 		st.ProjectID = p.UUID
 		if len(p.Backends) == 0 || p.Backends[p.StateBackendName] == nil {
-			st.BackendType = p.Backends[p.StateBackendName].Provider()
-		} else {
 			st.BackendType = "null"
+		} else {
+			st.BackendType = p.Backends[p.StateBackendName].Provider()
 		}
 	} else {
 		st.ProjectID = "null"

--- a/pkg/units/shell/terraform/helm/main.go
+++ b/pkg/units/shell/terraform/helm/main.go
@@ -149,7 +149,17 @@ func (u *Unit) ReadConfig(spec map[string]interface{}, stack *project.Stack) err
 			}
 			valuesFileName, ok := valuesCatMap["file"].(string)
 			if !ok {
-				return fmt.Errorf("read unit config: 'values.file' is required field")
+				setData, ok := valuesCatMap["set"].(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("read unit config: one of 'values.file' or 'values.set' required")
+				}
+				u.ValuesYAML = append(u.ValuesYAML, setData)
+				yamlDaya, err := yaml.Marshal(setData)
+				if err != nil {
+					return fmt.Errorf("read unit config: %w", err)
+				}
+				u.ValuesFilesList = append(u.ValuesFilesList, string(yamlDaya))
+				continue
 			}
 			vfPath := filepath.Join(u.Stack().TemplateDir, valuesFileName)
 			valuesFileContent, err := os.ReadFile(vfPath)


### PR DESCRIPTION
features:
 - helm unit now supports the `set` option in addition to the `file` option. this option allows you to transfer the value of the helm chart without saving it to a file..  Example:
```
    name: unitname
    type: helm
    source:
      chart: "my-chart"
      version: "0.0.23"
    kubeconfig: /file/path/conf.yaml
    values:
      - file: "./files/values.yaml"
        apply_template: false
      - set: {{ insertYAML .variables.chart_values }}
```
- fixes:  fixed promlem with `null` value in usage stats