### PR TITLE
stack disabled, message about usage stats moved to INFO log level

### DIFF
--- a/pkg/cmd/cdev/apply.go
+++ b/pkg/cmd/cdev/apply.go
@@ -1,8 +1,10 @@
 package cdev
 
 import (
+	"github.com/apex/log"
 	"github.com/shalb/cluster.dev/pkg/config"
 	"github.com/shalb/cluster.dev/pkg/project"
+	"github.com/shalb/cluster.dev/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -14,7 +16,9 @@ var applyCmd = &cobra.Command{
 	Short:         "Deploys or updates infrastructure according to project configuration",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		project, err := project.LoadProjectFull()
-
+		if utils.GetEnv("CDEV_COLLECT_USAGE_STATS", "false") == "true" {
+			log.Infof("Sending usage statistic. To disable statistics collection, export the CDEV_COLLECT_USAGE_STATS=false environment variable")
+		}
 		if err != nil {
 			return NewCmdErr(project, "apply", err)
 		}

--- a/pkg/project/stack.go
+++ b/pkg/project/stack.go
@@ -43,6 +43,9 @@ func (p *Project) readStacks() error {
 			return err
 		}
 	}
+	if len(p.Stacks) == 0 {
+		return fmt.Errorf("no stacks found, at least one needed")
+	}
 	return nil
 }
 
@@ -50,6 +53,17 @@ func (p *Project) readStackObj(stackSpec ObjectData) error {
 	name, ok := stackSpec.data["name"].(string)
 	if !ok {
 		return fmt.Errorf("stack object must contain field 'name'")
+	}
+	disabledInt := stackSpec.data["disabled"]
+	if disabledInt != nil {
+		disabled, ok := disabledInt.(bool)
+		if !ok {
+			return fmt.Errorf("stack option 'disabled' should be bool, not %T", disabledInt)
+		}
+		if disabled {
+			log.Debugf("stack '%v' is disabled, ignore", name)
+			return nil
+		}
 	}
 	// Check if stack with this name is already exists in project.
 	if _, ok = p.Stacks[name]; ok {

--- a/pkg/utils/stats_collector.go
+++ b/pkg/utils/stats_collector.go
@@ -46,7 +46,6 @@ func (e *StatsExporter) PushStats(stats interface{}) error {
 	client := http.Client{
 		Timeout: 3 * time.Second,
 	}
-	log.Warnf("Sending usage statistic. To disable statistics collection, export the CDEV_COLLECT_USAGE_STATS=false environment variable")
 	log.Debugf("Usage stats:\n%v", string(jsonBody))
 	res, err := client.Do(req)
 	if err != nil {

--- a/tests/test-project/local.yaml
+++ b/tests/test-project/local.yaml
@@ -1,6 +1,7 @@
 name: cdev-tests-local
 template: ./local-tmpl/
 kind: Stack
+disabled: false
 backend: aws-backend
 variables:
   data: {{ remoteState "cdev-tests.create-bucket.test" }}


### PR DESCRIPTION
Features: 
- added bool option `disabled` for stack object
Fix: 
- message about usage statistic sending moved to show after cdev start and changed from WARN to INFO log level