### PR TITLE
validate command

### DIFF
--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -127,15 +127,15 @@ func (b *Backend) Configure() error {
 	}
 
 	ctx := context.TODO()
-	_, awsConfig, diags := awsbase.GetAwsConfig(ctx, cfg)
+	_, awsConfig, _ := awsbase.GetAwsConfig(ctx, cfg)
 
-	if diags.HasError() {
-		diagError := fmt.Sprintln("s3 configuration diagnostics returns errors:")
-		for _, diag := range diags {
-			diagError = fmt.Sprintf("%s\nSummary: %s\nDetails: %s", diagError, diag.Summary(), diag.Detail())
-		}
-		return fmt.Errorf(diagError)
-	}
+	// if diags.HasError() {
+	// 	diagError := "s3 configuration diagnostics returns errors:"
+	// 	for _, diag := range diags {
+	// 		diagError = fmt.Sprintf("%s\nSummary: %s\nDetails: %s", diagError, diag.Summary(), diag.Detail())
+	// 	}
+	// 	return fmt.Errorf(diagError)
+	// }
 
 	b.s3Client = s3.NewFromConfig(awsConfig,
 		func(o *s3.Options) {

--- a/internal/cmd/cdev/project.go
+++ b/internal/cmd/cdev/project.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/gookit/color"
 	"github.com/shalb/cluster.dev/internal/config"
 	"github.com/shalb/cluster.dev/internal/project"
 	"github.com/shalb/cluster.dev/internal/project/ui"
@@ -20,17 +21,18 @@ var listAllTemplates bool
 
 func init() {
 	rootCmd.AddCommand(projectCmd)
-	projectCmd.AddCommand(projectLs)
+	projectCmd.AddCommand(projectInfo)
 	projectCmd.AddCommand(projectCreate)
 	projectCreate.Flags().BoolVar(&config.Global.Interactive, "interactive", false, "Use interactive mode for project generation")
 	projectCreate.Flags().BoolVar(&listAllTemplates, "list-templates", false, "Show all available templates for project generation")
 }
 
 // projectsCmd represents the plan command
-var projectLs = &cobra.Command{
+var projectInfo = &cobra.Command{
 	Use:   "info",
 	Short: "Shows detailed information about the current project, such as the number of units and their types. Number of stacks, etc",
 	Run: func(cmd *cobra.Command, args []string) {
+		config.Global.IgnoreState = true
 		p, err := project.LoadProjectFull()
 		if err != nil {
 			log.Errorf("Project configuration error: %v", err.Error())
@@ -38,6 +40,7 @@ var projectLs = &cobra.Command{
 		}
 		log.Info("Project info:")
 		p.PrintInfo()
+		log.Infof("Project configuration check: %v", color.Style{color.FgGreen, color.OpBold}.Sprintf("valid"))
 	},
 }
 

--- a/internal/cmd/cdev/validate.go
+++ b/internal/cmd/cdev/validate.go
@@ -1,0 +1,27 @@
+package cdev
+
+import (
+	"github.com/apex/log"
+	"github.com/gookit/color"
+	"github.com/shalb/cluster.dev/internal/config"
+	"github.com/shalb/cluster.dev/internal/project"
+	"github.com/spf13/cobra"
+)
+
+// projectsCmd represents the plan command
+var projectValidate = &cobra.Command{
+	Use:   "validate",
+	Short: "Validates the configuration files in a project directory, referring only to the configuration and not accessing remote state bucket",
+	Run: func(cmd *cobra.Command, args []string) {
+		config.Global.IgnoreState = true
+		_, err := project.LoadProjectFull()
+		if err != nil {
+			log.Fatalf("Project configuration check: %v\n%v", color.Style{color.FgGreen, color.OpBold}.Sprintf("fail"), err.Error())
+		}
+		log.Infof("Project configuration check: %v", color.Style{color.FgGreen, color.OpBold}.Sprintf("valid"))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(projectValidate)
+}


### PR DESCRIPTION
Features: 
- added new top level sub-command `cdev validate`. Command validates the configuration files in a project directory, referring only to the configuration and not accessing remote state bucket
- sub-command `cdev project info` also not accessing remote state bucket

<!-- 🛈

 Hello!

 Remember to ADD A DESCRIPTION and delete this note before submitting
 your pull request. The description should explain what will be changed,
 and why.

 For the detailed guidance on editing and submitting pull requests, please visit:
  - [docs/CONTRIBUTING.md](https://github.com/shalb/cluster.dev/blob/master/docs/CONTRIBUTING.md)
  - [docs/style-guide.md](https://github.com/shalb/cluster.dev/blob/master/docs/style-guide.md)
  - [CODE_OF_CONDUCT.md](https://github.com/shalb/cluster.dev/blob/master/CODE_OF_CONDUCT.md)
-->
